### PR TITLE
feat(Makefile): enable immutable (git-based) Docker tag publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,7 @@ SHORT_NAME := workflow-manager
 # Enable vendor/ directory support.
 export GO15VENDOREXPERIMENT=1
 
-# SemVer with build information is defined in the SemVer 2 spec, but Docker
-# doesn't allow +, so we use -.
-VERSION := git-$(shell git rev-parse --short HEAD)
+include versioning.mk
 
 DEV_ENV_IMAGE := quay.io/deis/go-dev:0.9.0
 DEV_ENV_WORK_DIR := /go/src/github.com/deis/${SHORT_NAME}
@@ -21,11 +19,6 @@ BINDIR := ./rootfs/bin
 ifdef ${DEV_REGISTRY}
   DEIS_REGISTRY = ${DEV_REGISTRY}/
 endif
-
-IMAGE_PREFIX ?= deis/
-
-# Docker image name
-IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}${SHORT_NAME}:${VERSION}
 
 all: build docker-build docker-push
 
@@ -47,7 +40,4 @@ test:
 # We also alter the RC file to set the image name.
 docker-build:
 	docker build --rm -t ${IMAGE} rootfs
-
-# Push to a registry that Kubernetes can access.
-docker-push:
-	docker push ${IMAGE}
+	docker tag -f ${IMAGE} ${MUTABLE_IMAGE}

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -5,7 +5,7 @@
 
 cd "$(dirname "$0")" || exit 1
 
-export IMAGE_PREFIX=deisci/ VERSION=v2-beta
+export IMAGE_PREFIX=deisci
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 DEIS_REGISTRY='' make -C .. docker-build docker-push
 docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io

--- a/versioning.mk
+++ b/versioning.mk
@@ -1,0 +1,23 @@
+MUTABLE_VERSION ?= canary
+VERSION ?= git-$(shell git rev-parse --short HEAD)
+IMAGE_PREFIX ?= deis
+
+IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}
+MUTABLE_IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${MUTABLE_VERSION}
+
+info:
+	@echo "Build tag:       ${VERSION}"
+	@echo "Registry:        ${DEIS_REGISTRY}"
+	@echo "Immutable tag:   ${IMAGE}"
+	@echo "Mutable tag:     ${MUTABLE_IMAGE}"
+
+.PHONY: docker-push
+docker-push: docker-immutable-push docker-mutable-push
+
+.PHONY: docker-immutable-push
+docker-immutable-push:
+	docker push ${IMAGE}
+
+.PHONY: docker-mutable-push
+docker-mutable-push:
+	docker push ${MUTABLE_IMAGE}


### PR DESCRIPTION
Based on https://github.com/deis/workflow/pull/487, and using a more cute name for the include `.mk` file just because!