### PR TITLE
fixing inconsisent build/deploy results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ bootstrap:
 # the build as a `docker build`.
 build:
 	mkdir -p ${BINDIR}
-	${DEV_ENV_CMD} go build -o ${BINDIR}/boot -a -installsuffix cgo -ldflags ${LDFLAGS} boot.go
+	${DEV_ENV_CMD} go build -o rootfs/bin/boot -a -installsuffix cgo -ldflags ${LDFLAGS} boot.go
 
 test:
 	${DEV_ENV_CMD} sh -c 'go test -v $$(glide nv)'

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ include versioning.mk
 
 DEV_ENV_IMAGE := quay.io/deis/go-dev:0.9.0
 DEV_ENV_WORK_DIR := /go/src/github.com/deis/${SHORT_NAME}
-DEV_ENV_CMD := docker run --rm -e CGO_ENABLED=0 -v ${PWD}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
+DEV_ENV_CMD := docker run --rm -e CGO_ENABLED=0 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
 
 # Common flags passed into Go's linker.
 LDFLAGS := "-s -X main.version=${VERSION}"
 
 # Docker Root FS
-BINDIR := ./rootfs/bin
+BINDIR := ${CURDIR}/rootfs/bin
 
 # Legacy support for DEV_REGISTRY, plus new support for DEIS_REGISTRY.
 ifdef ${DEV_REGISTRY}


### PR DESCRIPTION
CURDIR is more resilient.

See:

http://www.gnu.org/software/make/manual/html_node/Recursion.html