### PR TITLE
chore(.travis.yml): Stop deploying images from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,3 @@ install:
   - make bootstrap
 script:
   - make test build docker-build
-deploy:
-  provider: script
-  script: _scripts/deploy.sh
-  on:
-    branch: master


### PR DESCRIPTION
This stops Travis from carrying out deployments of Docker images, as we have agreed to transfer this responsibility to Jenkins.

cc @vdice @sgoings