### PR TITLE
ref(types): enforcing {} json-like objects for Version.Data

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -10,10 +10,10 @@ type Component struct {
 
 // Version type definition
 type Version struct {
-	Train    string `json:"train"` // e.g., "beta", "stable"
-	Version  string `json:"version"`
-	Released string `json:"released,omitempty"`
-	Data     []byte `json:"data"`
+	Train    string                 `json:"train"` // e.g., "beta", "stable"
+	Version  string                 `json:"version"`
+	Released string                 `json:"released,omitempty"`
+	Data     map[string]interface{} `json:"data"`
 }
 
 // ComponentVersion type definition


### PR DESCRIPTION
We expect the `Version.Data` property to be a root-level JSON object. E.g.,

```
{
  "notes": "this release marks our next evolution towards the Next Big Thing",
  "fixes": "now runs on 256 bit architecture"
}
```