### PR TITLE
fix(rootfs): copy only the built binary in the Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,6 @@ test:
 
 # For cases where we're building from local
 # We also alter the RC file to set the image name.
-docker-build:
+docker-build: build
 	docker build --rm -t ${IMAGE} rootfs
 	docker tag -f ${IMAGE} ${MUTABLE_IMAGE}

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -2,6 +2,6 @@ FROM alpine:3.3
 
 RUN apk -U add ca-certificates && \
     rm -Rf /var/cache/apk/*
-COPY . /
+COPY ./bin/boot /bin/boot
 EXPOSE 8080
 CMD ["/bin/boot"]


### PR DESCRIPTION
... instead of the entire bin directory. This will cause `docker build` commands to fail, instead of the docker image being pushed with no binary present.

This patch also fixes jenkins builds for workflow-manager

cc/ @jackfrancis 