### PR TITLE
ref(Makefile,rootfs/Dockerfile): use ubuntu-slim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ include versioning.mk
 
 DEV_ENV_IMAGE := quay.io/deis/go-dev:0.9.0
 DEV_ENV_WORK_DIR := /go/src/github.com/deis/${SHORT_NAME}
-DEV_ENV_CMD := docker run --rm -e CGO_ENABLED=0 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
+DEV_ENV_CMD := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
 
 # Common flags passed into Go's linker.
 LDFLAGS := "-s -X main.version=${VERSION}"

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,7 +1,5 @@
-FROM alpine:3.3
-
-RUN apk -U add ca-certificates && \
-    rm -Rf /var/cache/apk/*
+FROM gcr.io/google_containers/ubuntu-slim:0.2
 COPY ./bin/boot /bin/boot
+RUN apt-get update && apt-get -y install ca-certificates && apt-get clean
 EXPOSE 8080
 CMD ["/bin/boot"]


### PR DESCRIPTION
This patch allows us to build the workflow-manager with cgo enabled