### PR TITLE
ref(swagger): change the wfm API version and also remove https

### DIFF
--- a/api/swagger-spec/swagger.yml
+++ b/api/swagger-spec/swagger.yml
@@ -1,15 +1,14 @@
 swagger: "2.0"
 info:
   title: Workflow Manager
-  version: 1.0.0
-basePath: /v1
+  version: 2.0.0
+basePath: /v2
 produces:
   - application/json
 consumes:
   - application/json
 schemes:
   - http
-  - https
 paths:
   /versions/{train}/{component}/{release}:
     parameters:


### PR DESCRIPTION
- Changed the api version as there are few changes which might not be compatible with the old clients like the endpoint for creating a cluster is POST /cluster/{id} but we changed it to POST /cluster as the id is already part of the body and need not be specified.
- removed the https as it is taken care of the elb running in front of it
