### PR TITLE
ref(swagger): change the version version of wfm API and delete latest release endpoint

### DIFF
--- a/api/swagger-spec/swagger.yml
+++ b/api/swagger-spec/swagger.yml
@@ -2,7 +2,7 @@ swagger: "2.0"
 info:
   title: Workflow Manager
   version: 2.0.0
-basePath: /v2
+basePath: /v3
 produces:
   - application/json
 consumes:

--- a/api/swagger-spec/swagger.yml
+++ b/api/swagger-spec/swagger.yml
@@ -65,22 +65,6 @@ paths:
           description: unexpected error
           schema:
             $ref: "#/definitions/error"
-  /versions/{train}/{component}/latest:
-    get:
-      operationId: getComponentByLatestRelease
-      summary: "read the latest release of a component"
-      parameters:
-        - $ref: "#/parameters/trainParam"
-        - $ref: "#/parameters/componentParam"
-      responses:
-        200:
-          description: component latest release response
-          schema:
-            $ref: "#/definitions/componentVersion"
-        default:
-          description: unexpected error
-          schema:
-            $ref: "#/definitions/error"
   /versions/latest:
     post:
       operationId: getComponentsByLatestRelease


### PR DESCRIPTION
the /versions/{train}/{component}/latest endpoint is deleted because there is another endpoint /versions/{train}/{component}/{release} which is making the server ambiguous. 