### PR TITLE
ref(data): s/getDeisRCItems/getRCItems

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -139,9 +139,9 @@ func NewestSemVer(v1 string, v2 string) (string, error) {
 	return v1, nil
 }
 
-// getDeisRCItems is a helper function that returns a slice of
-// ReplicationController objects in the "deis" namespace
-func getDeisRCItems(rcLister rc.Lister) ([]api.ReplicationController, error) {
+// getRCItems is a helper function that returns a slice of
+// ReplicationController objects given a rc.Lister interface
+func getRCItems(rcLister rc.Lister) ([]api.ReplicationController, error) {
 	rcs, err := rcLister.List(api.ListOptions{
 		LabelSelector: labels.Everything(),
 	})

--- a/data/installed_data.go
+++ b/data/installed_data.go
@@ -25,7 +25,7 @@ func NewInstalledDeisData(rcl rc.Lister) InstalledData {
 
 // Get method for InstalledDeisData
 func (g *installedDeisData) Get() ([]byte, error) {
-	rcItems, err := getDeisRCItems(g.rcLister)
+	rcItems, err := getRCItems(g.rcLister)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This helper function was recently refactored; its original goal was to statically return ReplicationController objects in the "deis" namespace, but now its namespace (and other) specifications are passed in as an `rc.Lister`.

Thus, renaming the newer, generic rc items getter to `getRCItems` to reflect this.