### PR TITLE
chore(Makefile): update to go-dev 0.17.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,8 @@
 SHORT_NAME := workflow-manager
 
-# Enable vendor/ directory support.
-export GO15VENDOREXPERIMENT=1
-
 include versioning.mk
 
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.13.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.17.0
 SWAGGER_IMAGE := quay.io/goswagger/swagger:0.5.0
 DEV_ENV_WORK_DIR := /go/src/github.com/deis/${SHORT_NAME}
 DEV_ENV_CMD := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/base:0.2.0
+FROM quay.io/deis/base:0.3.1
 
 COPY . /
 


### PR DESCRIPTION
Includes the go 1.7 toolchain: faster, smaller, better. See https://tip.golang.org/doc/go1.7.

Also updates the Docker base image to deis/base:0.3.1.